### PR TITLE
Add link to Github repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "moniker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generate random names.",
   "author": "Ben Weaver <ben@orangesoda.net>",
-  "main": "./lib/moniker"
+  "main": "./lib/moniker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/weaver/moniker.git"
+  }
 }


### PR DESCRIPTION
Adding this little snippet will allow npmjs.org (https://www.npmjs.com/package/moniker) to show the README.md content inline and link back to the project on Github. There are other projects that have similar function and without this backlink it's hard to tell if that npm package refers to this project.

I've also taken the liberty to bump the version so all you have to do is run `npm publish` after merging this change.
