### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,9 @@
   "version": "0.1.2",
   "description": "Generate random names.",
   "author": "Ben Weaver <ben@orangesoda.net>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/weaver/moniker.git"
+  },
   "main": "./lib/moniker"
 }


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
*moniker